### PR TITLE
Building for OpenWrt snapshots: phase 1

### DIFF
--- a/.github/workflows/build-module-artifacts.yml
+++ b/.github/workflows/build-module-artifacts.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           path: openwrt
           repository: openwrt/openwrt
+          ref: 9772ca190ee45d33129ed2e0df3b3b7bd014a860
           fetch-depth: 0
 
       - name: checkout usign

--- a/.github/workflows/build-module-artifacts.yml
+++ b/.github/workflows/build-module-artifacts.yml
@@ -143,4 +143,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: amneziawg-${{ steps.build-amneziawg.outputs.version_str }}-openwrt-${{ matrix.build_env.tag }}-${{ matrix.build_env.pkgarch}}-${{ matrix.build_env.target}}-${{ matrix.build_env.subtarget}}
-          path: awgrelease/*
+          path: |
+            awgrelease/*.gz
+            awgrelease/test.pub-*
+            awgrelease/test.sec-*

--- a/.github/workflows/build-module-artifacts.yml
+++ b/.github/workflows/build-module-artifacts.yml
@@ -128,14 +128,15 @@ jobs:
           time -p make build-amneziawg
           make prepare-artifacts
 
-      - name: create feed
-        id: create-feed
+      - name: create feed archive
+        id: create-feed-archive
         run: |
           set -x
           cd amneziawg-openwrt
           usign -G -s test.sec -p test.pub
-          FEED_SEC_KEY=$(pwd)/test.sec make create-feed
-          FEED_PUB_KEY=$(pwd)/test.pub make verify-feed
+          FEED_SEC_KEY=$(pwd)/test.sec FEED_PUB_KEY=$(pwd)/test.pub make create-feed-archive
+          cp test.sec ./awgrelease/test.sec-${{ steps.build-amneziawg.outputs.version_str }}-openwrt-${{ matrix.build_env.tag }}-${{ matrix.build_env.pkgarch}}-${{ matrix.build_env.target}}-${{ matrix.build_env.subtarget}}
+          cp test.pub ./awgrelease/test.pub-${{ steps.build-amneziawg.outputs.version_str }}-openwrt-${{ matrix.build_env.tag }}-${{ matrix.build_env.pkgarch}}-${{ matrix.build_env.target}}-${{ matrix.build_env.subtarget}}
 
       - name: upload artifacts
         if: ${{ always() }}

--- a/.github/workflows/build-module-artifacts.yml
+++ b/.github/workflows/build-module-artifacts.yml
@@ -36,7 +36,7 @@ on:
         required: true
         default: "auto"
       openwrt_snapshot_ref:
-        description: "Git ref for snapshot"
+        description: "OpenWrt snapshot git ref"
         type: string
         required: false
         default: "main"

--- a/.github/workflows/build-module-artifacts.yml
+++ b/.github/workflows/build-module-artifacts.yml
@@ -35,6 +35,11 @@ on:
         type: string
         required: true
         default: "auto"
+      openwrt_snapshot_ref:
+        description: "Git ref for snapshot"
+        type: string
+        required: false
+        default: "main"
 
 jobs:
   build:
@@ -48,6 +53,7 @@ jobs:
             target: ${{ inputs.openwrt_target || vars.DEFAULT_OPENWRT_TARGET }}
             subtarget: ${{ inputs.openwrt_subtarget || vars.DEFAULT_OPENWRT_SUBTARGET }}
             vermagic: ${{ inputs.openwrt_vermagic || vars.DEFAULT_OPENWRT_VERMAGIC }}
+            snapshot_ref: ${{ inputs.openwrt_snapshot_ref || 'main' }}
 
     env:
       OPENWRT_RELEASE: ${{ matrix.build_env.tag }}
@@ -55,6 +61,7 @@ jobs:
       OPENWRT_TARGET: ${{ matrix.build_env.target }}
       OPENWRT_SUBTARGET: ${{ matrix.build_env.subtarget }}
       OPENWRT_VERMAGIC: ${{ matrix.build_env.vermagic }}
+      OPENWRT_SNAPSHOT_REF: ${{ matrix.build_env.snapshot_ref }}
 
     steps:
       - name: checkout amneziawg-openwrt
@@ -63,7 +70,7 @@ jobs:
           path: amneziawg-openwrt
           fetch-depth: 0
 
-      - name: checkout openwrt (tag)
+      - name: checkout openwrt (release)
         uses: actions/checkout@v4
         if: ${{ matrix.build_env.tag != 'snapshot' }}
         with:
@@ -72,13 +79,13 @@ jobs:
           ref: v${{ matrix.build_env.tag }}
           fetch-depth: 0
 
-      - name: checkout openwrt (main)
+      - name: checkout openwrt (snapshot)
         uses: actions/checkout@v4
         if: ${{ matrix.build_env.tag == 'snapshot' }}
         with:
           path: openwrt
           repository: openwrt/openwrt
-          ref: 9772ca190ee45d33129ed2e0df3b3b7bd014a860
+          ref: ${{ matrix.build_env.snapshot_ref }}
           fetch-depth: 0
 
       - name: checkout usign

--- a/.github/workflows/build-module-artifacts.yml
+++ b/.github/workflows/build-module-artifacts.yml
@@ -63,12 +63,21 @@ jobs:
           path: amneziawg-openwrt
           fetch-depth: 0
 
-      - name: checkout openwrt
+      - name: checkout openwrt (tag)
         uses: actions/checkout@v4
+        if: ${{ matrix.build_env.tag }} != 'snapshot'
         with:
           path: openwrt
           repository: openwrt/openwrt
           ref: v${{ matrix.build_env.tag }}
+          fetch-depth: 0
+
+      - name: checkout openwrt (main)
+        uses: actions/checkout@v4
+        if: ${{ matrix.build_env.tag }} == 'snapshot'
+        with:
+          path: openwrt
+          repository: openwrt/openwrt
           fetch-depth: 0
 
       - name: checkout usign

--- a/.github/workflows/build-module-artifacts.yml
+++ b/.github/workflows/build-module-artifacts.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: checkout openwrt (tag)
         uses: actions/checkout@v4
-        if: ${{ matrix.build_env.tag }} != 'snapshot'
+        if: ${{ matrix.build_env.tag != 'snapshot' }}
         with:
           path: openwrt
           repository: openwrt/openwrt
@@ -74,7 +74,7 @@ jobs:
 
       - name: checkout openwrt (main)
         uses: actions/checkout@v4
-        if: ${{ matrix.build_env.tag }} == 'snapshot'
+        if: ${{ matrix.build_env.tag == 'snapshot' }}
         with:
           path: openwrt
           repository: openwrt/openwrt

--- a/.github/workflows/build-module-artifacts.yml
+++ b/.github/workflows/build-module-artifacts.yml
@@ -135,8 +135,8 @@ jobs:
           cd amneziawg-openwrt
           usign -G -s test.sec -p test.pub
           FEED_SEC_KEY=$(pwd)/test.sec FEED_PUB_KEY=$(pwd)/test.pub make create-feed-archive
-          cp test.sec ./awgrelease/test.sec-${{ steps.build-amneziawg.outputs.version_str }}-openwrt-${{ matrix.build_env.tag }}-${{ matrix.build_env.pkgarch}}-${{ matrix.build_env.target}}-${{ matrix.build_env.subtarget}}
-          cp test.pub ./awgrelease/test.pub-${{ steps.build-amneziawg.outputs.version_str }}-openwrt-${{ matrix.build_env.tag }}-${{ matrix.build_env.pkgarch}}-${{ matrix.build_env.target}}-${{ matrix.build_env.subtarget}}
+          cp test.sec ../awgrelease/test.sec-${{ steps.build-amneziawg.outputs.version_str }}-openwrt-${{ matrix.build_env.tag }}-${{ matrix.build_env.pkgarch}}-${{ matrix.build_env.target}}-${{ matrix.build_env.subtarget}}
+          cp test.pub ../awgrelease/test.pub-${{ steps.build-amneziawg.outputs.version_str }}-openwrt-${{ matrix.build_env.tag }}-${{ matrix.build_env.pkgarch}}-${{ matrix.build_env.target}}-${{ matrix.build_env.subtarget}}
 
       - name: upload artifacts
         if: ${{ always() }}

--- a/.github/workflows/build-toolchain-cache.yml
+++ b/.github/workflows/build-toolchain-cache.yml
@@ -28,6 +28,11 @@ on:
         type: string
         required: true
         default: "auto"
+      openwrt_snapshot_ref:
+        description: "Git ref for snapshot"
+        type: string
+        required: false
+        default: "main"
 
 jobs:
   build:
@@ -41,6 +46,7 @@ jobs:
             target: ${{ inputs.openwrt_target || vars.DEFAULT_OPENWRT_TARGET }}
             subtarget: ${{ inputs.openwrt_subtarget || vars.DEFAULT_OPENWRT_SUBTARGET }}
             vermagic: ${{ inputs.openwrt_vermagic || vars.DEFAULT_OPENWRT_VERMAGIC }}
+            snapshot_ref: ${{ inputs.openwrt_snapshot_ref || 'main' }}
 
     env:
       OPENWRT_RELEASE: ${{ matrix.build_env.tag }}
@@ -48,6 +54,7 @@ jobs:
       OPENWRT_TARGET: ${{ matrix.build_env.target }}
       OPENWRT_SUBTARGET: ${{ matrix.build_env.subtarget }}
       OPENWRT_VERMAGIC: ${{ matrix.build_env.vermagic }}
+      OPENWRT_SNAPSHOT_REF: ${{ matrix.build_env.snapshot_ref }}
 
     steps:
       - name: checkout amneziawg-openwrt
@@ -56,7 +63,7 @@ jobs:
           path: amneziawg-openwrt
           fetch-depth: 0
 
-      - name: checkout openwrt (tag)
+      - name: checkout openwrt (release)
         uses: actions/checkout@v4
         if: ${{ matrix.build_env.tag != 'snapshot' }}
         with:
@@ -65,12 +72,13 @@ jobs:
           ref: v${{ matrix.build_env.tag }}
           fetch-depth: 0
 
-      - name: checkout openwrt (main)
+      - name: checkout openwrt (snapshot)
         uses: actions/checkout@v4
         if: ${{ matrix.build_env.tag == 'snapshot' }}
         with:
           path: openwrt
           repository: openwrt/openwrt
+          ref: ${{ matrix.build_env.snapshot_ref }}
           fetch-depth: 0
 
       - name: building toolchain and kernel

--- a/.github/workflows/build-toolchain-cache.yml
+++ b/.github/workflows/build-toolchain-cache.yml
@@ -29,7 +29,7 @@ on:
         required: true
         default: "auto"
       openwrt_snapshot_ref:
-        description: "Git ref for snapshot"
+        description: "OpenWrt snapshot git ref"
         type: string
         required: false
         default: "main"

--- a/.github/workflows/build-toolchain-cache.yml
+++ b/.github/workflows/build-toolchain-cache.yml
@@ -56,12 +56,21 @@ jobs:
           path: amneziawg-openwrt
           fetch-depth: 0
 
-      - name: checkout openwrt
+      - name: checkout openwrt (tag)
         uses: actions/checkout@v4
+        if: ${{ matrix.build_env.tag != 'snapshot' }}
         with:
           path: openwrt
           repository: openwrt/openwrt
           ref: v${{ matrix.build_env.tag }}
+          fetch-depth: 0
+
+      - name: checkout openwrt (main)
+        uses: actions/checkout@v4
+        if: ${{ matrix.build_env.tag == 'snapshot' }}
+        with:
+          path: openwrt
+          repository: openwrt/openwrt
           fetch-depth: 0
 
       - name: building toolchain and kernel

--- a/.github/workflows/multibuild-module-artifacts.yml
+++ b/.github/workflows/multibuild-module-artifacts.yml
@@ -124,8 +124,8 @@ jobs:
           cd amneziawg-openwrt
           usign -G -s test.sec -p test.pub
           FEED_SEC_KEY=$(pwd)/test.sec FEED_PUB_KEY=$(pwd)/test.pub make create-feed-archive
-          cp test.sec ./awgrelease/test.sec-${{ steps.build-amneziawg.outputs.version_str }}-openwrt-${{ matrix.build_env.tag }}-${{ matrix.build_env.pkgarch}}-${{ matrix.build_env.target}}-${{ matrix.build_env.subtarget}}
-          cp test.pub ./awgrelease/test.pub-${{ steps.build-amneziawg.outputs.version_str }}-openwrt-${{ matrix.build_env.tag }}-${{ matrix.build_env.pkgarch}}-${{ matrix.build_env.target}}-${{ matrix.build_env.subtarget}}
+          cp test.sec ../awgrelease/test.sec-${{ steps.build-amneziawg.outputs.version_str }}-openwrt-${{ matrix.build_env.tag }}-${{ matrix.build_env.pkgarch}}-${{ matrix.build_env.target}}-${{ matrix.build_env.subtarget}}
+          cp test.pub ../awgrelease/test.pub-${{ steps.build-amneziawg.outputs.version_str }}-openwrt-${{ matrix.build_env.tag }}-${{ matrix.build_env.pkgarch}}-${{ matrix.build_env.target}}-${{ matrix.build_env.subtarget}}
 
       - name: upload artifacts
         if: ${{ always() }}

--- a/.github/workflows/multibuild-module-artifacts.yml
+++ b/.github/workflows/multibuild-module-artifacts.yml
@@ -117,14 +117,15 @@ jobs:
           time -p make build-amneziawg
           make prepare-artifacts
 
-      - name: create feed
-        id: create-feed
+      - name: create feed archive
+        id: create-feed-archive
         run: |
           set -x
           cd amneziawg-openwrt
           usign -G -s test.sec -p test.pub
-          FEED_SEC_KEY=$(pwd)/test.sec make create-feed
-          FEED_PUB_KEY=$(pwd)/test.pub make verify-feed
+          FEED_SEC_KEY=$(pwd)/test.sec FEED_PUB_KEY=$(pwd)/test.pub make create-feed-archive
+          cp test.sec ./awgrelease/test.sec-${{ steps.build-amneziawg.outputs.version_str }}-openwrt-${{ matrix.build_env.tag }}-${{ matrix.build_env.pkgarch}}-${{ matrix.build_env.target}}-${{ matrix.build_env.subtarget}}
+          cp test.pub ./awgrelease/test.pub-${{ steps.build-amneziawg.outputs.version_str }}-openwrt-${{ matrix.build_env.tag }}-${{ matrix.build_env.pkgarch}}-${{ matrix.build_env.target}}-${{ matrix.build_env.subtarget}}
 
       - name: upload artifacts
         if: ${{ always() }}

--- a/.github/workflows/multibuild-module-artifacts.yml
+++ b/.github/workflows/multibuild-module-artifacts.yml
@@ -132,4 +132,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: amneziawg-${{ steps.build-amneziawg.outputs.version_str }}-openwrt-${{ matrix.build_env.tag }}-${{ matrix.build_env.pkgarch}}-${{ matrix.build_env.target}}-${{ matrix.build_env.subtarget}}
-          path: awgrelease/*
+          path: |
+            awgrelease/*.gz
+            awgrelease/test.pub-*
+            awgrelease/test.sec-*

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ OPENWRT_ARCH      ?= mips_24kc
 OPENWRT_TARGET    ?= ath79
 OPENWRT_SUBTARGET ?= generic
 OPENWRT_VERMAGIC  ?= auto
+OPENWRT_SNAPSHOT_REF ?= main
 
 # for generate-target-matrix
 OPENWRT_RELEASES  ?= $(OPENWRT_RELEASE)
@@ -88,6 +89,7 @@ SHOW_ENV_VARS = \
 	OPENWRT_TARGET \
 	OPENWRT_SUBTARGET \
 	OPENWRT_VERMAGIC \
+	OPENWRT_SNAPSHOT_REF \
 	OPENWRT_BASE_URL \
 	OPENWRT_MANIFEST \
 	OPENWRT_PKG_EXT \
@@ -149,11 +151,14 @@ github-build-artifacts: ## Run GitHub workflow to build amneziawg OpenWrt packag
 
 $(OPENWRT_SRCDIR):
 	@{ \
-	set -ex ; \
+	set -eux ; \
 	git clone https://github.com/openwrt/openwrt.git $@ ; \
 	if [ "$(OPENWRT_RELEASE)" != "snapshot" ]; then \
 		cd $@ ; \
 		git checkout v$(OPENWRT_RELEASE) ; \
+	else \
+		cd $@ ; \
+		git checkout $(OPENWRT_SNAPSHOT_REF) ; \
 	fi ; \
 	}
 

--- a/Makefile
+++ b/Makefile
@@ -253,9 +253,9 @@ prepare-artifacts: ## Save amneziawg-openwrt artifacts from regular builds
 	set -ex ; \
 	cd $(OPENWRT_SRCDIR) ; \
 	mkdir -p $(AMNEZIAWG_DSTDIR)/$(OPENWRT_RELEASE)/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET) ; \
-	cp bin/packages/$(OPENWRT_ARCH)/awgopenwrt/amneziawg-tools_*$(OPENWRT_PKG_EXT) $(AMNEZIAWG_DSTDIR)/$(OPENWRT_RELEASE)/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)/ ; \
-	cp bin/packages/$(OPENWRT_ARCH)/awgopenwrt/luci-proto-amneziawg_*$(OPENWRT_PKG_EXT) $(AMNEZIAWG_DSTDIR)/$(OPENWRT_RELEASE)/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)/ ; \
-	cp bin/targets/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)/packages/kmod-amneziawg_*$(OPENWRT_PKG_EXT) $(AMNEZIAWG_DSTDIR)/$(OPENWRT_RELEASE)/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)/ ; \
+	cp bin/packages/$(OPENWRT_ARCH)/awgopenwrt/amneziawg-tools*$(OPENWRT_PKG_EXT) $(AMNEZIAWG_DSTDIR)/$(OPENWRT_RELEASE)/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)/ ; \
+	cp bin/packages/$(OPENWRT_ARCH)/awgopenwrt/luci-proto-amneziawg*$(OPENWRT_PKG_EXT) $(AMNEZIAWG_DSTDIR)/$(OPENWRT_RELEASE)/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)/ ; \
+	cp bin/targets/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)/packages/kmod-amneziawg*$(OPENWRT_PKG_EXT) $(AMNEZIAWG_DSTDIR)/$(OPENWRT_RELEASE)/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)/ ; \
 	}
 
 .PHONY: check-release

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,15 @@ FEED_NAME         := amneziawg-opkg-feed-$(GITHUB_REF_NAME)-openwrt-$(OPENWRT_RE
 
 WORKFLOW_REF      ?= $(shell git rev-parse --abbrev-ref HEAD)
 
+ifneq ($(OPENWRT_RELEASE),snapshot)
 OPENWRT_ROOT_URL  ?= https://downloads.openwrt.org/releases
 OPENWRT_BASE_URL  ?= $(OPENWRT_ROOT_URL)/$(OPENWRT_RELEASE)/targets/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)
 OPENWRT_MANIFEST  ?= $(OPENWRT_BASE_URL)/openwrt-$(OPENWRT_RELEASE)-$(OPENWRT_TARGET)-$(OPENWRT_SUBTARGET).manifest
+else
+OPENWRT_ROOT_URL  ?= https://downloads.openwrt.org/snapshots
+OPENWRT_BASE_URL  ?= $(OPENWRT_ROOT_URL)/targets/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)
+OPENWRT_MANIFEST  ?= $(OPENWRT_BASE_URL)/openwrt-$(OPENWRT_TARGET)-$(OPENWRT_SUBTARGET).manifest
+endif
 
 NPROC ?= $(shell getconf _NPROCESSORS_ONLN)
 
@@ -39,7 +45,11 @@ _NEED_VERMAGIC=1
 endif
 
 ifeq ($(_NEED_VERMAGIC), 1)
+ifneq ($(OPENWRT_RELEASE),snapshot)
 OPENWRT_VERMAGIC := $(shell curl -fs $(OPENWRT_MANIFEST) | grep -- "^kernel" | sed -e "s,.*\-,,")
+else
+OPENWRT_VERMAGIC := $(shell curl -fs $(OPENWRT_MANIFEST) | grep -- "^kernel" | sed -e "s,.*\~,," | cut -d '-' -f 1)
+endif
 endif
 
 ifndef USIGN

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ OPENWRT_RELEASES  ?= $(OPENWRT_RELEASE)
 GITHUB_SHA        ?= $(shell git rev-parse --short HEAD)
 VERSION_STR       ?= $(shell git describe --tags --long --dirty)
 POSTFIX           := $(VERSION_STR)_v$(OPENWRT_RELEASE)_$(OPENWRT_ARCH)_$(OPENWRT_TARGET)_$(OPENWRT_SUBTARGET)
-FEED_NAME         := amneziawg-opkg-feed-$(GITHUB_REF_NAME)-openwrt-$(OPENWRT_RELEASE)-$(OPENWRT_ARCH)-$(OPENWRT_TARGET)-$(OPENWRT_SUBTARGET)
+FEED_NAME         := amneziawg-opkg-feed-$(VERSION_STR)-openwrt-$(OPENWRT_RELEASE)-$(OPENWRT_ARCH)-$(OPENWRT_TARGET)-$(OPENWRT_SUBTARGET)
 
 WORKFLOW_REF      ?= $(shell git rev-parse --abbrev-ref HEAD)
 

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,12 @@ ifneq ($(OPENWRT_RELEASE),snapshot)
 OPENWRT_ROOT_URL  ?= https://downloads.openwrt.org/releases
 OPENWRT_BASE_URL  ?= $(OPENWRT_ROOT_URL)/$(OPENWRT_RELEASE)/targets/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)
 OPENWRT_MANIFEST  ?= $(OPENWRT_BASE_URL)/openwrt-$(OPENWRT_RELEASE)-$(OPENWRT_TARGET)-$(OPENWRT_SUBTARGET).manifest
+OPENWRT_PKG_EXT   := .ipk
 else
 OPENWRT_ROOT_URL  ?= https://downloads.openwrt.org/snapshots
 OPENWRT_BASE_URL  ?= $(OPENWRT_ROOT_URL)/targets/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)
 OPENWRT_MANIFEST  ?= $(OPENWRT_BASE_URL)/openwrt-$(OPENWRT_TARGET)-$(OPENWRT_SUBTARGET).manifest
+OPENWRT_PKG_EXT   := .apk
 endif
 
 NPROC ?= $(shell getconf _NPROCESSORS_ONLN)
@@ -88,6 +90,7 @@ SHOW_ENV_VARS = \
 	OPENWRT_VERMAGIC \
 	OPENWRT_BASE_URL \
 	OPENWRT_MANIFEST \
+	OPENWRT_PKG_EXT \
 	NPROC
 
 show-var-%:
@@ -250,9 +253,9 @@ prepare-artifacts: ## Save amneziawg-openwrt artifacts from regular builds
 	set -ex ; \
 	cd $(OPENWRT_SRCDIR) ; \
 	mkdir -p $(AMNEZIAWG_DSTDIR)/$(OPENWRT_RELEASE)/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET) ; \
-	cp bin/packages/$(OPENWRT_ARCH)/awgopenwrt/amneziawg-tools_*.ipk $(AMNEZIAWG_DSTDIR)/$(OPENWRT_RELEASE)/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)/ ; \
-	cp bin/packages/$(OPENWRT_ARCH)/awgopenwrt/luci-proto-amneziawg_*.ipk $(AMNEZIAWG_DSTDIR)/$(OPENWRT_RELEASE)/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)/ ; \
-	cp bin/targets/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)/packages/kmod-amneziawg_*.ipk $(AMNEZIAWG_DSTDIR)/$(OPENWRT_RELEASE)/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)/ ; \
+	cp bin/packages/$(OPENWRT_ARCH)/awgopenwrt/amneziawg-tools_*$(OPENWRT_PKG_EXT) $(AMNEZIAWG_DSTDIR)/$(OPENWRT_RELEASE)/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)/ ; \
+	cp bin/packages/$(OPENWRT_ARCH)/awgopenwrt/luci-proto-amneziawg_*$(OPENWRT_PKG_EXT) $(AMNEZIAWG_DSTDIR)/$(OPENWRT_RELEASE)/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)/ ; \
+	cp bin/targets/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)/packages/kmod-amneziawg_*$(OPENWRT_PKG_EXT) $(AMNEZIAWG_DSTDIR)/$(OPENWRT_RELEASE)/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)/ ; \
 	}
 
 .PHONY: check-release
@@ -295,7 +298,7 @@ create-feed: | $(FEED_PATH) ## Create package feed
 	set -eux ; \
 	target_path=$(FEED_PATH)/$(OPENWRT_RELEASE)/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)/ ; \
 	mkdir -p $${target_path} ; \
-	for pkg in $$(find $(AMNEZIAWG_DSTDIR)/ -type f -name "*.ipk"); do \
+	for pkg in $$(find $(AMNEZIAWG_DSTDIR)/ -type f -name "*$(OPENWRT_PKG_EXT)"); do \
 		cp $${pkg} $${target_path}/ ; \
 	done ; \
 	( cd $${target_path} && $(TOPDIR)/scripts/ipkg-make-index.sh . >Packages && $(USIGN) -S -m Packages -s $(FEED_SEC_KEY) -x Packages.sig && gzip -fk Packages ) ; \

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,13 @@ OPENWRT_ROOT_URL  ?= https://downloads.openwrt.org/releases
 OPENWRT_BASE_URL  ?= $(OPENWRT_ROOT_URL)/$(OPENWRT_RELEASE)/targets/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)
 OPENWRT_MANIFEST  ?= $(OPENWRT_BASE_URL)/openwrt-$(OPENWRT_RELEASE)-$(OPENWRT_TARGET)-$(OPENWRT_SUBTARGET).manifest
 OPENWRT_PKG_EXT   := .ipk
+PACKAGE_SCRIPT    := ipkg-make-index.sh
 else
 OPENWRT_ROOT_URL  ?= https://downloads.openwrt.org/snapshots
 OPENWRT_BASE_URL  ?= $(OPENWRT_ROOT_URL)/targets/$(OPENWRT_TARGET)/$(OPENWRT_SUBTARGET)
 OPENWRT_MANIFEST  ?= $(OPENWRT_BASE_URL)/openwrt-$(OPENWRT_TARGET)-$(OPENWRT_SUBTARGET).manifest
 OPENWRT_PKG_EXT   := .apk
+PACKAGE_SCRIPT    := apk-make-index.sh
 endif
 
 NPROC ?= $(shell getconf _NPROCESSORS_ONLN)
@@ -304,7 +306,7 @@ create-feed: | $(FEED_PATH) ## Create package feed
 	for pkg in $$(find $(AMNEZIAWG_DSTDIR)/ -type f -name "*$(OPENWRT_PKG_EXT)"); do \
 		cp $${pkg} $${target_path}/ ; \
 	done ; \
-	( cd $${target_path} && $(TOPDIR)/scripts/ipkg-make-index.sh . >Packages && $(USIGN) -S -m Packages -s $(FEED_SEC_KEY) -x Packages.sig && gzip -fk Packages ) ; \
+	( cd $${target_path} && $(TOPDIR)/scripts/$(PACKAGE_SCRIPT) . >Packages && $(USIGN) -S -m Packages -s $(FEED_SEC_KEY) -x Packages.sig && gzip -fk Packages ) ; \
 	cat $${target_path}/Packages ; \
 	}
 

--- a/Makefile
+++ b/Makefile
@@ -148,8 +148,10 @@ $(OPENWRT_SRCDIR):
 	@{ \
 	set -ex ; \
 	git clone https://github.com/openwrt/openwrt.git $@ ; \
-	cd $@ ; \
-	git checkout v$(OPENWRT_RELEASE) ; \
+	if [ "$(OPENWRT_RELEASE)" != "snapshot" ]; then \
+		cd $@ ; \
+		git checkout v$(OPENWRT_RELEASE) ; \
+	fi ; \
 	}
 
 $(OPENWRT_SRCDIR)/feeds.conf: | $(OPENWRT_SRCDIR)

--- a/Makefile
+++ b/Makefile
@@ -278,16 +278,19 @@ check-release: ## Verify that everything is in place for tagged release
 	fi ; \
 	}
 
-.PHONY: prepare-release
-prepare-release: check-release ## Save amneziawg-openwrt artifacts from tagged release
+.PHONY: create-feed-archive
+create-feed-archive: ## Create archive of a package feed
 	@{ \
-	set -ex ; \
+	set -eux ; \
 	cd $(OPENWRT_SRCDIR) ; \
 	mkdir -p $(AMNEZIAWG_DSTDIR) ; \
 	FEED_PATH="$(AMNEZIAWG_DSTDIR)/$(FEED_NAME)" $(MAKE) -f $(SELF) create-feed ; \
 	FEED_PATH="$(AMNEZIAWG_DSTDIR)/$(FEED_NAME)" $(MAKE) -f $(SELF) verify-feed ; \
 	tar -C $(AMNEZIAWG_DSTDIR)/$(FEED_NAME) -czvf $(AMNEZIAWG_DSTDIR)/$(FEED_NAME).tar.gz $(OPENWRT_RELEASE)/ ; \
 	}
+
+.PHONY: prepare-release
+prepare-release: check-release create-feed-archive ## Save amneziawg-openwrt artifacts from tagged release
 
 $(FEED_PATH):
 	mkdir -p $@
@@ -302,6 +305,7 @@ create-feed: | $(FEED_PATH) ## Create package feed
 		cp $${pkg} $${target_path}/ ; \
 	done ; \
 	( cd $${target_path} && $(TOPDIR)/scripts/ipkg-make-index.sh . >Packages && $(USIGN) -S -m Packages -s $(FEED_SEC_KEY) -x Packages.sig && gzip -fk Packages ) ; \
+	cat $${target_path}/Packages ; \
 	}
 
 .PHONY: verify-feed

--- a/luci-proto-amneziawg/Makefile
+++ b/luci-proto-amneziawg/Makefile
@@ -7,7 +7,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_MAINTAINER:=Amnezia Admin <admin@amnezia.org>
-PKG_VERSION:=0.0.1-1
+PKG_VERSION:=0.0.1
+PKG_RELEASE:=1
 LUCI_TITLE:=AmneziaWG Web UI
 LUCI_DESCRIPTION:=Provides Web UI for AmneziaWG
 LUCI_DEPENDS:=+luci-base +amneziawg-tools +ucode

--- a/scripts/apk-make-index.sh
+++ b/scripts/apk-make-index.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "TODO: not yet"

--- a/scripts/apk-make-index.sh
+++ b/scripts/apk-make-index.sh
@@ -1,5 +1,40 @@
 #!/usr/bin/env bash
+# apk v3 repository index control tool
+# TODO: add signing + verifying with signatures
 
-set -e
+set -euxo pipefail
 
-echo "TODO: not yet"
+usage() {
+    echo "usage: $(basename "$0") {create,verify,dump} pkg_path" >&2
+    exit 1
+}
+
+if [ $# -lt 2 ]; then
+    usage
+fi
+
+ACTION="$1"
+PKG_PATH="$2"
+
+if [ ! -d "${PKG_PATH}" ]; then
+    echo "${PKG_PATH}: directory not found" >&2
+    exit 1
+fi
+
+case "${ACTION}" in
+    create)
+        echo "Creating packages.adb index in ${PKG_PATH}" >&2
+        ( cd "${PKG_PATH}" && ${APK} mkndx --allow-untrusted --output packages.adb -- *.apk )
+        ;;
+    verify)
+        echo "Verifying packages.adb in ${PKG_PATH}" >&2
+        ${APK} verify --allow-untrusted "${PKG_PATH}/packages.adb"
+        ;;
+    dump)
+        echo "Dumping packages.adb in ${PKG_PATH}" >&2
+        ${APK} adbdump "${PKG_PATH}/packages.adb" | tee "${PKG_PATH}/packages.adb.txt"
+        ;;
+    *)
+        echo "unknown action: ${ACTION}" >&2
+        usage
+esac

--- a/scripts/generate_target_matrix.py
+++ b/scripts/generate_target_matrix.py
@@ -119,9 +119,12 @@ class OpenWrtBuildInfoFetcher:
             subtarget = _jobs[i]["subtarget"]
 
             # BeautifulSoup solution (commented below) takes a while, so use plain regex here
-            packages = re.findall(r'href="(kernel_.*ipk)"', res[i])
+            packages = re.findall(r'href="(kernel[_-].*[ia]pk)"', res[i])
+            logger.debug("kernel packages found: %s", packages)
             for package in packages:
                 logger.debug("%s/%s: found kernel: %s", target, subtarget, package)
+
+                # regular (release) builds
                 m = re.match(
                     r"kernel_\d+\.\d+\.\d+(?:-\d+)?[-~]([a-f0-9]+)(?:-r\d+)?_([a-zA-Z0-9_-]+)\.ipk$",
                     package,
@@ -129,6 +132,17 @@ class OpenWrtBuildInfoFetcher:
                 if m:
                     self.targets[target][subtarget]["vermagic"] = m.group(1)
                     self.targets[target][subtarget]["pkgarch"] = m.group(2)
+                    break
+
+                # snapshot builds
+                m = re.match(
+                    r"kernel-\d+\.\d+\.\d+(?:-\d+)?[-~]([a-f0-9]+)(?:-r\d+)\.apk$",
+                    package,
+                )
+                if m:
+                    self.targets[target][subtarget]["vermagic"] = m.group(1)
+                    # TODO: figure out how to populate this correctly
+                    self.targets[target][subtarget]["pkgarch"] = "none"
                     break
 
             # s = BeautifulSoup(res[i], 'html.parser')

--- a/scripts/generate_target_matrix.py
+++ b/scripts/generate_target_matrix.py
@@ -16,7 +16,8 @@ logger = logging.getLogger(os.path.basename(__file__))
 
 # filtered targets for release builds
 TARGETS_TO_BUILD = ["ath79"]
-SUBTARGETS_TO_BUILD = ["generic", "nand"]
+#SUBTARGETS_TO_BUILD = ["generic", "nand"]
+SUBTARGETS_TO_BUILD = ["generic"]
 
 # filtered targets for snapshot builds
 SNAPSHOT_TARGETS_TO_BUILD = ["ath79"]

--- a/scripts/ipkg-make-index.sh
+++ b/scripts/ipkg-make-index.sh
@@ -25,7 +25,7 @@ fi
 
 empty=1
 
-for pkg in `find $pkg_dir -name '*.ipk' -o -name '*.apk' | sort`; do
+for pkg in `find $pkg_dir -name '*.ipk' | sort`; do
 	empty=
 	name="${pkg##*/}"
 	name="${name%%_*}"

--- a/scripts/ipkg-make-index.sh
+++ b/scripts/ipkg-make-index.sh
@@ -25,7 +25,7 @@ fi
 
 empty=1
 
-for pkg in `find $pkg_dir -name '*.ipk' | sort`; do
+for pkg in `find $pkg_dir -name '*.ipk' -o -name '*.apk' | sort`; do
 	empty=
 	name="${pkg##*/}"
 	name="${name%%_*}"


### PR DESCRIPTION
This PR is intended to put some ground for building amneziawg packages for OpenWrt snapshots. The following limitations are currently in place:
1. GitHub cache key for toolchain does _not_ include OpenWrt commit SHA, so be careful in using default ref for snapshots (`main`): reusing caches built from older sources could case various issues if there were updates to main OpenWrt branch between toolchain cache creation and build-module-artifacts workflow run.
2. OpenWrt snapshots migrated to [apk package manager](https://wiki.alpinelinux.org/wiki/Alpine_Package_Keeper) (Alpine Package Keeper) v3 with binary package indices. As of now, package feeds provided by CI pipelines of this repo do _not_ use package/repo index signing.

Docs part: https://github.com/defanator/amneziawg-openwrt?tab=readme-ov-file#building-amneziawg-packages-for-openwrt-snapshot

Relates to https://github.com/defanator/amneziawg-openwrt/issues/3.