### PR TITLE
Refactor build matrix creation and update targets

### DIFF
--- a/.github/workflows/create-release-from-multibuild.yml
+++ b/.github/workflows/create-release-from-multibuild.yml
@@ -12,7 +12,7 @@ on:
         description: "OpenWrt version(s)"
         type: string
         required: true
-        default: "24.10.2 23.05.5 23.05.3"
+        default: "24.10.5 23.05.3"
 
 jobs:
   generate-target-matrix:

--- a/.github/workflows/multibuild-module-artifacts.yml
+++ b/.github/workflows/multibuild-module-artifacts.yml
@@ -12,7 +12,7 @@ on:
         description: "OpenWrt version(s)"
         type: string
         required: true
-        default: "24.10.2 23.05.5 23.05.3"
+        default: "24.10.5 23.05.3"
 
 jobs:
   generate-target-matrix:

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ venv: .venv ## Create virtualenv
 
 .PHONY: generate-target-matrix
 generate-target-matrix: .venv ## Generate target matrix of build environments for GitHub CI
-	@printf "BUILD_MATRIX=%s" "$$($(TOPDIR)/.venv/bin/python3 $(TOPDIR)/scripts/generate_target_matrix.py $(OPENWRT_RELEASES))"
+	@printf "BUILD_MATRIX=%s" "$$($(TOPDIR)/.venv/bin/python3 $(TOPDIR)/scripts/generate_target_matrix.py --config $(TOPDIR)/target-matrix-config.yaml)"
 
 .PHONY: github-build-cache
 github-build-cache: ## Run GitHub workflow to create OpenWrt toolchain and kernel cache (use WORKFLOW_REF to specify branch/tag)

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ venv: .venv ## Create virtualenv
 
 .PHONY: generate-target-matrix
 generate-target-matrix: .venv ## Generate target matrix of build environments for GitHub CI
-	@printf "BUILD_MATRIX=%s" "$$($(TOPDIR)/.venv/bin/python3 $(TOPDIR)/scripts/generate_target_matrix.py --config $(TOPDIR)/target-matrix-config.yaml)"
+	@printf "BUILD_MATRIX=%s" "$$($(TOPDIR)/.venv/bin/python3 $(TOPDIR)/scripts/generate_target_matrix.py --config $(TOPDIR)/target-matrix-config.yaml $(OPENWRT_RELEASES))"
 
 .PHONY: github-build-cache
 github-build-cache: ## Run GitHub workflow to create OpenWrt toolchain and kernel cache (use WORKFLOW_REF to specify branch/tag)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4>=4.12.3
 aiohttp>=3.11.11
+PyYAML>=6.0

--- a/scripts/generate_target_matrix.py
+++ b/scripts/generate_target_matrix.py
@@ -158,6 +158,11 @@ async def main():
         help="YAML configuration file specifying OpenWrt versions and targets",
     )
     parser.add_argument(
+        "version",
+        nargs="*",
+        help="OpenWrt version(s) to build (must exist in config file). If none specified, returns empty array.",
+    )
+    parser.add_argument(
         "--verbose", action="store_true", default=False, help="enable logging"
     )
     args = parser.parse_args()
@@ -188,8 +193,37 @@ async def main():
         )
         return 1
 
+    # If no versions specified, return empty array
+    if not args.version:
+        logger.info("No versions specified, returning empty array")
+        print(json.dumps(job_config, separators=(",", ":")))
+        logger.info("stopped")
+        return 0
+
+    # Validate that all specified versions exist in config
+    missing_versions = []
+    for version in args.version:
+        if version not in config:
+            missing_versions.append(version)
+
+    if missing_versions:
+        logger.error(
+            "The following versions are not found in config file %s: %s",
+            args.config,
+            ", ".join(missing_versions),
+        )
+        logger.error("Available versions in config: %s", ", ".join(config.keys()))
+        return 1
+
+    # Process only the specified versions
+    versions_to_process = set(args.version)
+
     try:
         for version_str, target_config in config.items():
+            # Skip versions not requested
+            if version_str not in versions_to_process:
+                continue
+
             if not isinstance(target_config, dict):
                 logger.warning(
                     "Skipping invalid target config for version %s: expected dictionary",

--- a/scripts/generate_target_matrix.py
+++ b/scripts/generate_target_matrix.py
@@ -20,10 +20,10 @@ class OpenWrtBuildInfoFetcher:
     def __init__(self, version, target_config):
         self._session = None
         self.url = "https://downloads.openwrt.org/"
-        self.version = version.lower()
+        self.version = version
         self.target_config = target_config
 
-        if self.version == "snapshot":
+        if self.version.lower() == "snapshot":
             self.base_uri = "/snapshots/targets/"
         else:
             self.base_uri = f"/releases/{version}/targets/"
@@ -226,10 +226,13 @@ async def main():
         logger.info("stopped")
         return 0
 
+    config_versions = set(v.lower() for v in config.keys())
+    versions_to_process = set(v.lower() for v in args.version)
+
     # Validate that all specified versions exist in config
     missing_versions = []
-    for version in args.version:
-        if version not in config:
+    for version in versions_to_process:
+        if version not in config_versions:
             missing_versions.append(version)
 
     if missing_versions:
@@ -238,14 +241,15 @@ async def main():
             args.config,
             ", ".join(missing_versions),
         )
-        logger.error("Available versions in config: %s", ", ".join(config.keys()))
+        logger.error(
+            "Available versions in config: %s", ", ".join(sorted(config_versions))
+        )
         return 1
-
-    # Process only the specified versions
-    versions_to_process = set(args.version)
 
     try:
         for version_str, target_config in config.items():
+            version_str = version_str.lower()
+
             # Skip versions not requested
             if version_str not in versions_to_process:
                 continue

--- a/scripts/generate_target_matrix.py
+++ b/scripts/generate_target_matrix.py
@@ -147,6 +147,32 @@ class OpenWrtBuildInfoFetcher:
             #            self.targets[target][subtarget]["pkgarch"] = m.group(2)
             #            break
 
+    def validate_config(self):
+        """Validate that all configured targets/subtargets exist on downloads site."""
+        missing_combinations = []
+
+        for target in self.target_config:
+            if target not in self.targets:
+                for subtarget in self.target_config[target]:
+                    missing_combinations.append(f"{target}/{subtarget}")
+            else:
+                for subtarget in self.target_config[target]:
+                    if subtarget not in self.targets[target]:
+                        missing_combinations.append(f"{target}/{subtarget}")
+
+        if missing_combinations:
+            logger.error(
+                "Invalid target/subtarget combinations found in configuration:"
+            )
+            for combo in sorted(missing_combinations):
+                logger.error("  - %s", combo)
+            logger.error(
+                "These combinations do not exist on the OpenWrt downloads site."
+            )
+            raise Exception(
+                f"Validation failed: {len(missing_combinations)} invalid target/subtarget combinations"
+            )
+
 
 async def main():
     parser = argparse.ArgumentParser(
@@ -239,6 +265,7 @@ async def main():
                 await of.get_targets()
                 await of.get_subtargets()
                 await of.get_details()
+                of.validate_config()
 
             for target, subtargets in of.targets.items():
                 for subtarget in subtargets:

--- a/scripts/generate_target_matrix.py
+++ b/scripts/generate_target_matrix.py
@@ -10,25 +10,18 @@ import logging
 import json
 import asyncio
 import aiohttp
+import yaml
 from bs4 import BeautifulSoup
 
 logger = logging.getLogger(os.path.basename(__file__))
 
-# filtered targets for release builds
-TARGETS_TO_BUILD = ["ath79"]
-#SUBTARGETS_TO_BUILD = ["generic", "nand"]
-SUBTARGETS_TO_BUILD = ["generic"]
-
-# filtered targets for snapshot builds
-SNAPSHOT_TARGETS_TO_BUILD = ["ath79"]
-SNAPSHOT_SUBTARGETS_TO_BUILD = ["generic", "nand"]
-
 
 class OpenWrtBuildInfoFetcher:
-    def __init__(self, version):
+    def __init__(self, version, target_config):
         self._session = None
         self.url = "https://downloads.openwrt.org/"
         self.version = version.lower()
+        self.target_config = target_config
 
         if self.version == "snapshot":
             self.base_uri = "/snapshots/targets/"
@@ -67,9 +60,9 @@ class OpenWrtBuildInfoFetcher:
         for element in s.select("table tr td.n a"):
             name = element.get("href")
             if name and name.endswith("/"):
-                if len(TARGETS_TO_BUILD) > 0 and name[:-1] not in TARGETS_TO_BUILD:
-                    continue
-                self.targets[name[:-1]] = {}
+                target_name = name[:-1]
+                if target_name in self.target_config:
+                    self.targets[target_name] = {}
 
     async def get_subtargets(self):
         logger.info("fetching subtargets")
@@ -87,15 +80,12 @@ class OpenWrtBuildInfoFetcher:
             for element in s.select("table tr td.n a"):
                 name = element.get("href")
                 if name and name.endswith("/"):
-                    if (
-                        len(SUBTARGETS_TO_BUILD) > 0
-                        and name[:-1] not in SUBTARGETS_TO_BUILD
-                    ):
-                        continue
-                    self.targets[target][name[:-1]] = {
-                        "vermagic": None,
-                        "pkgarch": None,
-                    }
+                    subtarget_name = name[:-1]
+                    if subtarget_name in self.target_config[target]:
+                        self.targets[target][subtarget_name] = {
+                            "vermagic": None,
+                            "pkgarch": None,
+                        }
 
     async def get_details(self):
         logger.info("fetching details")
@@ -163,9 +153,9 @@ async def main():
         description="Generate build matrix for amneziawg-openwrt GitHub CI"
     )
     parser.add_argument(
-        "version",
-        help="OpenWrt version (use SNAPSHOT for building against snapshots)",
-        nargs="+",
+        "--config",
+        required=True,
+        help="YAML configuration file specifying OpenWrt versions and targets",
     )
     parser.add_argument(
         "--verbose", action="store_true", default=False, help="enable logging"
@@ -181,16 +171,37 @@ async def main():
     logger.info("started")
     job_config = []
 
-    versions = set()
-    for version in args.version:
-        if version.lower() in versions:
-            logger.warning("duplicate version ignored: %s", version)
-            continue
-        versions.add(version.lower())
+    # Load YAML configuration
+    try:
+        with open(args.config, "r", encoding="utf-8") as config_file:
+            config = yaml.safe_load(config_file)
+    except FileNotFoundError:
+        logger.error("Configuration file not found: %s", args.config)
+        return 1
+    except yaml.YAMLError as e:
+        logger.error("Error parsing YAML configuration: %s", e)
+        return 1
+
+    if not isinstance(config, dict):
+        logger.error(
+            "Invalid configuration format: expected dictionary with version keys"
+        )
+        return 1
 
     try:
-        for version in versions:
-            async with OpenWrtBuildInfoFetcher(version=version) as of:
+        for version_str, target_config in config.items():
+            if not isinstance(target_config, dict):
+                logger.warning(
+                    "Skipping invalid target config for version %s: expected dictionary",
+                    version_str,
+                )
+                continue
+
+            logger.info("Processing version: %s", version_str)
+
+            async with OpenWrtBuildInfoFetcher(
+                version=version_str, target_config=target_config
+            ) as of:
                 await of.get_targets()
                 await of.get_subtargets()
                 await of.get_details()
@@ -199,7 +210,7 @@ async def main():
                 for subtarget in subtargets:
                     job_config.append(
                         {
-                            "tag": version,
+                            "tag": version_str,
                             "target": target,
                             "subtarget": subtarget,
                             "vermagic": of.targets[target][subtarget]["vermagic"],

--- a/scripts/generate_target_matrix.py
+++ b/scripts/generate_target_matrix.py
@@ -174,6 +174,33 @@ class OpenWrtBuildInfoFetcher:
             )
 
 
+def validate_config_schema(config):
+    """Validate that config has the correct schema."""
+    if not isinstance(config, dict):
+        raise ValueError("Configuration must be a dictionary with version keys")
+
+    for version, target_config in config.items():
+        if not isinstance(target_config, dict):
+            raise ValueError(
+                f"Configuration for version '{version}' must be a dictionary with target keys, "
+                f"got {type(target_config).__name__}"
+            )
+
+        for target, subtargets in target_config.items():
+            if not isinstance(subtargets, list):
+                raise ValueError(
+                    f"Subtargets for version '{version}', target '{target}' must be a list, "
+                    f"got {type(subtargets).__name__}: {subtargets}"
+                )
+
+            for i, subtarget in enumerate(subtargets):
+                if not isinstance(subtarget, str):
+                    raise ValueError(
+                        f"Subtarget {i} for version '{version}', target '{target}' must be a string, "
+                        f"got {type(subtarget).__name__}: {subtarget}"
+                    )
+
+
 async def main():
     parser = argparse.ArgumentParser(
         description="Generate build matrix for amneziawg-openwrt GitHub CI"
@@ -217,6 +244,12 @@ async def main():
         logger.error(
             "Invalid configuration format: expected dictionary with version keys"
         )
+        return 1
+
+    try:
+        validate_config_schema(config)
+    except ValueError as e:
+        logger.error("Configuration validation failed: %s", e)
         return 1
 
     # If no versions specified, return empty array

--- a/target-matrix-config.yaml
+++ b/target-matrix-config.yaml
@@ -1,0 +1,36 @@
+# OpenWrt build target matrix configuration
+#
+# This YAML file defines which OpenWrt targets and subtargets to build for each version.
+# The script will only build combinations explicitly listed here, giving you precise
+# control over the build matrix.
+#
+# Structure:
+# <version>:
+#   <target>: [list of subtargets]
+#
+# Supported versions:
+# - Release versions: 23.05.3, 23.05.5, 24.10.2, etc.
+# - Snapshot builds: use "SNAPSHOT" (case-sensitive)
+#
+# Common targets/subtargets combinations:
+# - ath79: ["generic", "nand"] - Atheros AR79xx/QCA series routers
+# - mediatek: ["filogic"] - MediaTek MT series routers
+# - ramips: ["mt7621", "mt76x8"] - Ralink/MediaTek MIPS routers
+# - x86: ["64"] - x86_64 systems
+#
+# The script will query the OpenWrt downloads site to verify each target/subtarget
+# exists for the specified version and extract kernel version information.
+
+23.05.3:
+  ath79:
+    - generic
+
+24.10.5:
+  ath79:
+    - generic
+  mediatek:
+    - filogic
+
+# snapshot builds use newer package format (.apk vs .ipk)
+#SNAPSHOT:
+#  ath79: ["generic"]

--- a/target-matrix-config.yaml
+++ b/target-matrix-config.yaml
@@ -32,5 +32,5 @@
     - filogic
 
 # snapshot builds use newer package format (.apk vs .ipk)
-#SNAPSHOT:
-#  ath79: ["generic"]
+snapshot:
+  ath79: ["generic"]


### PR DESCRIPTION
This PR introduces highly customizable format of configuration for creating build matrix, e.g.:

```yaml
23.05.3:
  ath79:
    - generic

24.10.5:
  ath79:
    - generic
  mediatek:
    - filogic

snapshot:
  ath79: ["generic"]
```

while preserving established ways of triggering build pipelines (e.g. passing a list of releases via dispatch variables).

(The CI part could be extended at a later stage to accept custom configuration instead of releases list.)